### PR TITLE
no longer linux32, now linux

### DIFF
--- a/starbound/server/steamcmd/server_start
+++ b/starbound/server/steamcmd/server_start
@@ -8,5 +8,5 @@ sed -i "s/PASSWORD/${STEAM_PASSWORD}/g" /server/steamcmd/starbound_update.txt
 /server/steamcmd/steamcmd.sh +runscript starbound_update.txt
 
 # Run the starbound server
-cd /server/steamcmd/starbound/linux32
+cd /server/steamcmd/starbound/linux
 ./starbound_server


### PR DESCRIPTION
Had trouble getting your docker container to work - found (for me anyway) that its no longer 'linux32' but rather just 'linux'

This patch fixes that and I tested it with quay.io/venezia/starbound-server